### PR TITLE
Update memory module imports for latest LangChain namespaces

### DIFF
--- a/backend/memory.py
+++ b/backend/memory.py
@@ -1,8 +1,9 @@
 import os, json
 from typing import List, Tuple
+
 from langchain_openai import OpenAIEmbeddings
-from langchain.schema import Document
-from langchain.vectorstores import Chroma
+from langchain_core.documents import Document
+from langchain_community.vectorstores import Chroma
 from redis import Redis
 
 CHROMA_DIR = os.getenv("CHROMA_DIR","./.chroma")


### PR DESCRIPTION
## Summary
- switch the memory module to import `Document` from `langchain_core.documents`
- update the Chroma vector store import to use `langchain_community.vectorstores`

## Testing
- `python -m pip install -r backend/requirements.txt`
- `uvicorn app:app --host 0.0.0.0 --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68cc7e6924bc8329ac56e16ed97f9c1c